### PR TITLE
[Feature] Redirects to Admin Installer on Tonics Fresh Installation

### DIFF
--- a/bin/restart_service.json
+++ b/bin/restart_service.json
@@ -1,1 +1,1 @@
-{"info":"The timestamp would be changed whenever an app\/module is updated, deleted, installed, this way, you can restart any services running in bin\/console","timestamp":1715641646}
+{"info":"The timestamp would be changed whenever an app\/module is updated, deleted, installed, this way, you can restart any services running in bin\/console","timestamp":1715801617}

--- a/src/Apps/TonicsCloud/Controllers/DomainController.php
+++ b/src/Apps/TonicsCloud/Controllers/DomainController.php
@@ -408,8 +408,8 @@ class DomainController
         $slug = 'dns_domain';
         $slugUnique = TonicsCloudActivator::getTable(TonicsCloudActivator::TONICS_CLOUD_DNS) .':dns_domain';
         if ($updateRule) {
-            $slug = 'dns_id';
-            $slugUnique = TonicsCloudActivator::getTable(TonicsCloudActivator::TONICS_CLOUD_DNS) .':dns_domain:dns_id';
+            $slug = 'slug_id';
+            $slugUnique = TonicsCloudActivator::getTable(TonicsCloudActivator::TONICS_CLOUD_DNS) .':dns_domain:slug_id';
         }
 
         return [

--- a/src/Apps/TonicsCloud/EventHandlers/CloudDNSHandler/LinodeCloudDNSHandler.php
+++ b/src/Apps/TonicsCloud/EventHandlers/CloudDNSHandler/LinodeCloudDNSHandler.php
@@ -197,6 +197,14 @@ class LinodeCloudDNSHandler implements HandlerInterface, CloudDNSInterface
      */
     private function getLinodeClient(): LinodeClient
     {
+        return self::LinodeClient();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public static function LinodeClient(): LinodeClient
+    {
         return new LinodeClient(TonicsCloudSettingsController::getSettingsData(TonicsCloudSettingsController::LinodeAPIToken));
     }
 

--- a/src/Apps/TonicsCloud/Jobs/Container/CloudJobQueueCreateContainer.php
+++ b/src/Apps/TonicsCloud/Jobs/Container/CloudJobQueueCreateContainer.php
@@ -50,7 +50,7 @@ class CloudJobQueueCreateContainer extends AbstractJobInterface implements JobHa
         } else {
             $source = [
                 "protocol" => "simplestreams",
-                "alias" => "debian/bullseye/amd64",
+                "alias" => "debian/bookworm/amd64",
                 "server" => "https://images.linuxcontainers.org",
                 "type" => "image"
             ];

--- a/src/Apps/TonicsCloud/Library/Incus/Repositories/Certificate.php
+++ b/src/Apps/TonicsCloud/Library/Incus/Repositories/Certificate.php
@@ -30,12 +30,8 @@ class Certificate extends AbstractRepository
      * The certificate field can be omitted in which case the TLS client
      * certificate in use for the connection will be retrieved and added to thetrust store.
      *
-     * <br>
-     *
      * Note: Sometimes, you would receive a 404 with the message: The provided certificate isn't valid yet, this is because of sync issue,
      * so, it is your responsibility to check for that error and retry adding it.
-     *
-     * <br>
      *
      * Here is an example
      * ```
@@ -96,7 +92,7 @@ class Certificate extends AbstractRepository
      * @return \stdClass
      * @throws \Exception
      */
-    public function delete(string $fingerPrint)
+    public function delete(string $fingerPrint): \stdClass
     {
         return $this->client->sendRequest($this->getEndPoint($fingerPrint), $this->client->getURL()::REQUEST_DELETE);
 

--- a/src/Apps/TonicsCloud/Library/Incus/Repositories/Instance.php
+++ b/src/Apps/TonicsCloud/Library/Incus/Repositories/Instance.php
@@ -372,11 +372,7 @@ class Instance extends AbstractRepository
     /**
      * Trigger a snapshot restore, use the `rename()` method to rename an instance.
      *
-     * <br>
-     *
      * If you know, all you want to do is update the description, please use the `patch()` method instead
-     *
-     * <br>
      *
      * Here is an example that triggers a snapshot restore:
      *
@@ -384,7 +380,6 @@ class Instance extends AbstractRepository
      * $client->instances()->update('instance-name', ["restore" => "snapshot_name"]);
      * ```
      *
-     * <br>
      * To update a device config, you first need to get the info of the instance, then update it like so, without that, it won't work:
      *
      * ```
@@ -432,8 +427,6 @@ class Instance extends AbstractRepository
 
     /**
      * Creates or replace file in the instance (You can also create a directory).
-     *
-     * <br>
      *
      * Here is an example:
      *

--- a/src/Apps/TonicsCloud/Views/Domain/edit.html
+++ b/src/Apps/TonicsCloud/Views/Domain/edit.html
@@ -8,6 +8,10 @@
 
 [[hook_into('Core::form_action')/customer/tonics_cloud/domains/[[v('DomainData.slug_id')]]/update]]
 
+[[hook_into('Core::before_form_section')
+    <input type="hidden" name="slug_id" value="[[v('DomainData.slug_id')]]">
+]]
+
 [[hook_into('Core::before_footer')
     [[_use("script:post")]]
     [[_use("session:delete-artifacts")]]

--- a/src/Modules/Core/Boot/HttpMessageProvider.php
+++ b/src/Modules/Core/Boot/HttpMessageProvider.php
@@ -53,7 +53,14 @@ class HttpMessageProvider implements ServiceProvider
         try {
             $this->getRouter()->dispatchRequestURL();
         } catch (\Exception|\Throwable $e) {
+
             if ($e->getCode() === 404) {
+
+                # Go-To Installer Page if 404 and tonics is not ready
+                if (AppConfig::TonicsIsNotReady()) {
+                    redirect(\route('admin.installer'));
+                }
+
                 $redirect_to = $this->tryURLRedirection();
                 $reURL = url()->getRequestURL();
                 if ($redirect_to === false) {

--- a/src/Modules/Core/Boot/InitLoader.php
+++ b/src/Modules/Core/Boot/InitLoader.php
@@ -72,14 +72,14 @@ class InitLoader
      */
     public function BootDaBoot(): void
     {
-        if (AppConfig::isMaintenanceMode()){
+        if (AppConfig::isMaintenanceMode()) {
             die("Temporarily down for schedule maintenance, check back in few minutes");
         }
 
                 #-----------------------------------
             # HEADERS SETTINGS TEST
         #-----------------------------------
-        if (AppConfig::TonicsIsReady()){
+        if (AppConfig::TonicsIsReady()) {
             response()->headers([
                 'Access-Control-Allow-Origin: ' . AppConfig::getAppUrl(),
                 'Access-Control-Allow-Credentials: true',
@@ -92,6 +92,7 @@ class InitLoader
                 'Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()',
             ]);
         }
+
                 #----------------------------------------------------
             # GATHER ROUTES AND PREPARE FOR PROCESSING
         #---------------------------------------------------

--- a/src/Modules/Core/RequestInterceptor/RedirectToInstallerOnTonicsNotReady.php
+++ b/src/Modules/Core/RequestInterceptor/RedirectToInstallerOnTonicsNotReady.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ *     Copyright (c) 2022-2024. Olayemi Faruq <olayemi@tonics.app>
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Modules\Core\RequestInterceptor;
+
+use App\Modules\Core\Configs\AppConfig;
+use App\Modules\Core\Library\SimpleState;
+use Devsrealm\TonicsRouterSystem\Events\OnRequestProcess;
+use Devsrealm\TonicsRouterSystem\Interfaces\TonicsRouterRequestInterceptorInterface;
+
+
+class RedirectToInstallerOnTonicsNotReady  extends SimpleState implements TonicsRouterRequestInterceptorInterface
+{
+    /**
+     * @inheritDoc
+     * @throws \Exception
+     * @throws \Throwable
+     */
+    public function handle(OnRequestProcess $request): void
+    {
+        if (AppConfig::TonicsIsNotReady()) {
+            redirect(\route('admin.installer'));
+        }
+    }
+}

--- a/src/Modules/Core/Routes/Routes.php
+++ b/src/Modules/Core/Routes/Routes.php
@@ -36,6 +36,7 @@ use App\Modules\Core\RequestInterceptor\InstallerChecker;
 use App\Modules\Core\RequestInterceptor\RedirectAuthenticated;
 use App\Modules\Core\RequestInterceptor\AppAccess;
 use App\Modules\Core\RequestInterceptor\RedirectAuthenticatedToCorrectDashboard;
+use App\Modules\Core\RequestInterceptor\RedirectToInstallerOnTonicsNotReady;
 use Devsrealm\TonicsRouterSystem\Route;
 
 trait Routes
@@ -47,18 +48,15 @@ trait Routes
     public function routeWeb(Route $route): Route
     {
 
-        # experiment with table layout
-        //$route->get("/table", [DashboardController::class, 'table']);
-
         ## For WEB
         $route->group('/admin', function (Route $route){
 
                     #---------------------------------
                 # INSTALLER...
             #---------------------------------
-            $route->get('installer', [Installer::class, 'showInstallerForm'], requestInterceptor: [InstallerChecker::class]);
+            $route->get('installer', [Installer::class, 'showInstallerForm'], requestInterceptor: [InstallerChecker::class], alias: 'installer');
 
-            $route->group('', function (Route $route){
+            $route->group('', function (Route $route) {
 
                 $route->group('', function (Route $route){
 
@@ -108,7 +106,7 @@ trait Routes
                     $route->post('/reset/verify_email', [ForgotPasswordController::class, 'reset'], alias: 'update');
                 }, alias: 'password');
 
-            }, AuthConfig::getCSRFRequestInterceptor());
+            }, AuthConfig::getCSRFRequestInterceptor([RedirectToInstallerOnTonicsNotReady::class]));
 
         }, alias: 'admin');
 

--- a/src/Modules/Customer/Routes/RouteWeb.php
+++ b/src/Modules/Customer/Routes/RouteWeb.php
@@ -23,6 +23,7 @@ use App\Modules\Core\Configs\AuthConfig;
 use App\Modules\Core\RequestInterceptor\Authenticated;
 use App\Modules\Core\RequestInterceptor\RedirectAuthenticated;
 use App\Modules\Core\RequestInterceptor\RedirectAuthenticatedToCorrectDashboard;
+use App\Modules\Core\RequestInterceptor\RedirectToInstallerOnTonicsNotReady;
 use App\Modules\Customer\Controllers\CustomerAuth\ForgotPasswordController;
 use App\Modules\Customer\Controllers\CustomerAuth\LoginController;
 use App\Modules\Customer\Controllers\CustomerAuth\RegisterController;
@@ -86,7 +87,7 @@ trait RouteWeb
                 $route->get('order/tonicscloud/:slug_id', [OrderController::class, 'tonicsCloudPurchaseDetails'], alias: 'order.tonicscloud.details');
 
             }, [Authenticated::class, RedirectCustomerGuest::class, CustomerAccess::class]);
-        }, AuthConfig::getCSRFRequestInterceptor(),  'customer');
+        }, AuthConfig::getCSRFRequestInterceptor([RedirectToInstallerOnTonicsNotReady::class]),  'customer');
 
         return $route;
     }


### PR DESCRIPTION
- On New TonicsCMS Installation, visiting the website, redirects you to the admin installer page
- Added a Middleware that redirects to the admin installer page, and prevents accessing the admin or customer area until Tonic is installed 

_Note: The only user that can install Tonics is whoever have the environmental `INSTALL_KEY`, check the env file for that or generate one if it isn't already generated_