### PR TITLE
[Bugfix] Rsync missing sometimes and other fixes

### DIFF
--- a/src/Apps/TonicsCloud/Apps/TonicsCloudScript.php
+++ b/src/Apps/TonicsCloud/Apps/TonicsCloudScript.php
@@ -174,6 +174,22 @@ SCRIPT;
     /**
      * @return string
      */
+    public static function StaticSiteScript (): string
+    {
+        return <<<'SCRIPT'
+chown -R "www-data:www-data" [[ROOT]]
+
+#
+#   Change permission of all directory and files
+find [[ROOT]] -type d -exec chmod 755 {} \;
+find [[ROOT]] -type f -exec chmod 644 {} \;
+SCRIPT;
+
+    }
+
+    /**
+     * @return string
+     */
     public static function TonicsCloudScript (): string
     {
         return <<<'SCRIPT'

--- a/src/Apps/TonicsCloud/Apps/TonicsCloudUnZip.php
+++ b/src/Apps/TonicsCloud/Apps/TonicsCloudUnZip.php
@@ -53,6 +53,7 @@ JSON;
     /**
      * @inheritDoc
      * @throws \Exception
+     * @throws \Throwable
      */
     public function updateSettings (): bool
     {
@@ -81,7 +82,7 @@ JSON;
      */
     public function install (): bool
     {
-        return $this->runCommand(null, null, "bash", "-c", "apt update -y && apt-get install -y atool wget");
+        return $this->runCommand(null, null, "bash", "-c", "apt update -y && apt-get install -y atool wget rsync");
     }
 
     /**

--- a/src/Apps/TonicsCloud/Jobs/Container/Automations/CloudJobQueueAutomationMultipleStaticSite.php
+++ b/src/Apps/TonicsCloud/Jobs/Container/Automations/CloudJobQueueAutomationMultipleStaticSite.php
@@ -20,6 +20,7 @@ namespace App\Apps\TonicsCloud\Jobs\Container\Automations;
 
 
 use App\Apps\TonicsCloud\Apps\TonicsCloudNginx;
+use App\Apps\TonicsCloud\Apps\TonicsCloudScript;
 use App\Apps\TonicsCloud\Jobs\App\CloudJobQueueUpdateApp;
 use App\Apps\TonicsCloud\Jobs\Container\Traits\TonicsJobQueueAutomationTrait;
 use App\Apps\TonicsCloud\Jobs\Container\Traits\TonicsJobQueueContainerTrait;
@@ -60,6 +61,7 @@ class CloudJobQueueAutomationMultipleStaticSite extends AbstractJobInterface imp
                 [
                     self::APP_SETTING_SIMPLE_NGINX_HTTP_MODE,
                     self::APP_SETTING_UNZIP,
+                    self::APP_SETTING_TONICS_SCRIPT => ['content' => TonicsCloudScript::StaticSiteScript()],
                 ],
                 $this->getContainerID()),
         ]);

--- a/src/Apps/TonicsCloud/Jobs/Container/Automations/CloudJobQueueAutomationStandaloneStaticSite.php
+++ b/src/Apps/TonicsCloud/Jobs/Container/Automations/CloudJobQueueAutomationStandaloneStaticSite.php
@@ -19,6 +19,7 @@
 namespace App\Apps\TonicsCloud\Jobs\Container\Automations;
 
 
+use App\Apps\TonicsCloud\Apps\TonicsCloudScript;
 use App\Apps\TonicsCloud\Jobs\App\CloudJobQueueUpdateApp;
 use App\Apps\TonicsCloud\Jobs\Container\Traits\TonicsJobQueueAutomationTrait;
 use App\Apps\TonicsCloud\Jobs\Container\Traits\TonicsJobQueueContainerTrait;
@@ -61,6 +62,7 @@ class CloudJobQueueAutomationStandaloneStaticSite extends AbstractJobInterface i
                     self::APP_SETTING_ACME,
                     self::APP_SETTING_SIMPLE_NGINX_HTTPS_MODE,
                     self::APP_SETTING_UNZIP,
+                    self::APP_SETTING_TONICS_SCRIPT => ['content' => TonicsCloudScript::StaticSiteScript()],
                 ],
                 $this->getCurrentContainerID()),
         ]);


### PR DESCRIPTION
- Depending on the image you are using, rsync might not be installed by default, to avoid uncertainty, we make attempt to install it regardless of if the image has one or not
- Due to the way the updated` TonicsCloudUnzip` works, there might be permission issue, so, there is now a Script config after each deployment for static sites that takes care of that.