### PR TITLE
[BugFix] 🐛 Critical error when a module or app is deleted and update

### DIFF
--- a/src/Modules/Core/Configs/AppConfig.php
+++ b/src/Modules/Core/Configs/AppConfig.php
@@ -721,12 +721,22 @@ class AppConfig
         return APP_ROOT . DIRECTORY_SEPARATOR . '.env';
     }
 
+    /**
+     * @param string $class
+     *
+     * @return bool
+     */
     public static function isInternalModuleNameSpace (string $class): bool
     {
         $moduleNameSpace = 'App\Modules';
         return str_starts_with($class, $moduleNameSpace);
     }
 
+    /**
+     * @param string|object $object_or_class
+     *
+     * @return bool
+     */
     public static function isAppNameSpace (string|object $object_or_class): bool
     {
         if (is_object($object_or_class)) {
@@ -736,5 +746,29 @@ class AppConfig
         return str_starts_with($object_or_class, $moduleNameSpace);
     }
 
+    /**
+     * This returns true if the namespace exist in either App or Modules directory
+     *
+     * @param $namespace
+     *
+     * @return bool
+     */
+    public static function nameSpaceExistPath ($namespace): bool
+    {
+        $baseDir = '';
+        $sep = DIRECTORY_SEPARATOR;
+        if (AppConfig::isInternalModuleNameSpace($namespace)) {
+            $baseDir = AppConfig::getModulesPath();
+            $namespace = str_replace("\\", $sep, $namespace);
+            $namespace = str_replace("App{$sep}Modules$sep", '', $namespace);
+        } elseif (AppConfig::isAppNameSpace($namespace)) {
+            $baseDir = AppConfig::getAppsPath();
+            $namespace = str_replace("\\", $sep, $namespace);
+            $namespace = str_replace("App{$sep}Apps$sep", '', $namespace);
+        }
 
+        // Combine the base directory with the relative path
+        $filePath = rtrim($baseDir, $sep) . $sep . $namespace . '.php';
+        return file_exists($filePath);
+    }
 }

--- a/src/Modules/Core/States/UpdateMechanismState.php
+++ b/src/Modules/Core/States/UpdateMechanismState.php
@@ -513,7 +513,7 @@ class UpdateMechanismState extends SimpleState
     /**
      * Return true if...
      *
-     * - If classString implements teh ExtensionConfig interface
+     * - If classString implements the ExtensionConfig interface
      * - The updates property is not empty
      * - there is an update
      *
@@ -529,6 +529,11 @@ class UpdateMechanismState extends SimpleState
         if (is_object($objectOrClass)) {
             $objectOrClass = $objectOrClass::class;
         }
+
+        if (!AppConfig::nameSpaceExistPath($objectOrClass)) {
+            return false;
+        }
+
         $ref = new \ReflectionClass($objectOrClass);
         $dir = dirname($ref->getFileName());
         $dirName = helper()->getFileName($dir);


### PR DESCRIPTION
This is an interesting bug, if an App or Module is deleted (for module, maybe you deleted it manually), if you try to update an active App, the update will proceed, but a critical error would be raised and halts the application. 

From my investigation, this is due to composer cached classmaps, deleting apps/module doesn't affect it, and since I don't want composer in production, I refactored the UpdateMechanism to check if the app namespace actually exist in the file, before we do anything.